### PR TITLE
Removed NUnit references from EditorCallerGate, mark test classes as …

### DIFF
--- a/.Dev-App/Unity/Assets/Tests/ProjectWideReplaceTests.cs
+++ b/.Dev-App/Unity/Assets/Tests/ProjectWideReplaceTests.cs
@@ -13,6 +13,7 @@ using UnityEngine.UI;
 
 namespace GuiToolkit.Test
 {
+	[EditorAware]
 	public class ProjectWideReplaceTests
 	{
 		[Test]

--- a/.Dev-App/Unity/Assets/Tests/RoslynComponentReplacerTests.cs
+++ b/.Dev-App/Unity/Assets/Tests/RoslynComponentReplacerTests.cs
@@ -11,6 +11,7 @@ using UnityEngine.UI;
 
 namespace GuiToolkit.Test
 {
+	[EditorAware]
 	public class RoslynComponentReplacerTests
 	{
 		[Test]

--- a/.Dev-App/Unity/Assets/Tests/TestEditorAssetUtility.cs
+++ b/.Dev-App/Unity/Assets/Tests/TestEditorAssetUtility.cs
@@ -9,6 +9,7 @@ using System;
 
 namespace GuiToolkit.Test
 {
+	[EditorAware]
 	public class TestEditorAssetUtility
 	{
 		[Test]

--- a/.Dev-App/Unity/Assets/Tests/TestEditorCodeUtility.cs
+++ b/.Dev-App/Unity/Assets/Tests/TestEditorCodeUtility.cs
@@ -15,6 +15,7 @@ using UnityEditor;
 
 namespace GuiToolkit.Test
 {
+	[EditorAware]
 	public class TestEditorCodeUtility
 	{
 		GameObject go1, go2;

--- a/.Dev-App/Unity/Assets/Tests/TestIPoolable.cs
+++ b/.Dev-App/Unity/Assets/Tests/TestIPoolable.cs
@@ -4,6 +4,7 @@ using UnityEngine.TestTools;
 
 namespace GuiToolkit.Test
 {
+	[EditorAware]
 	public class TestIPoolable
 	{
 		private GameObject m_prefab;

--- a/.Dev-App/Unity/Assets/Tests/TestPrefabInfo.cs
+++ b/.Dev-App/Unity/Assets/Tests/TestPrefabInfo.cs
@@ -7,6 +7,7 @@ using UnityEngine.TestTools;
 
 namespace GuiToolkit.Test
 {
+	[EditorAware]
 	public class TestPrefabInfo
 	{
 		[Test]

--- a/.Dev-App/Unity/Assets/Tests/TestUiPool.cs
+++ b/.Dev-App/Unity/Assets/Tests/TestUiPool.cs
@@ -4,6 +4,7 @@ using UnityEngine.TestTools;
 
 namespace GuiToolkit.Test
 {
+	[EditorAware]
 	public class TestUiPool
 	{
 		private GameObject m_prefabA;

--- a/Runtime/Code/Helpers/EditorCallerGate.cs
+++ b/Runtime/Code/Helpers/EditorCallerGate.cs
@@ -8,7 +8,6 @@ using UnityEngine;
 
 #if UNITY_EDITOR
 using System.Reflection;
-using NUnit.Framework;
 using UnityEditor;
 #endif
 
@@ -50,10 +49,6 @@ namespace GuiToolkit
 				// Skip compiler-generated (lambdas/async state machines)
 				if (currentType.IsDefined(typeof(CompilerGeneratedAttribute), false))
 					continue;
-				
-				// Tests are assumed to always be editor aware
-				if (currentMethod.IsDefined(typeof(TestAttribute), false))
-					return true;
 				
 				if (currentType.Name.Length > 0 && currentType.Name[0] == '<')
 					continue;


### PR DESCRIPTION
…[EditorAware] instead.

Otherwise, NUnit framework needed to be installed in client project.