### PR TITLE
Give AGENTS.md its meta file

### DIFF
--- a/AGENTS.md.meta
+++ b/AGENTS.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f3ceea0ef29ed6260fb037129c4b5cf3
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
Follow-up to #115. AGENTS.md shipped without its .meta file, and a package under Packages/ is an immutable folder, so every consuming project logs:

    Asset Packages/de.phoenixgrafik.ui-toolkit/AGENTS.md has no meta file, but it's in an immutable folder. The asset will be ignored.

Same omission BEST-PRACTICES.md had earlier. Swept the rest of the tracked files while here — AGENTS.md was the only one missing a meta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)